### PR TITLE
Ignore common symbol and output to console as debug

### DIFF
--- a/app/widgets/net.hoyohoyo.zuruiline/controllers/widget.js
+++ b/app/widgets/net.hoyohoyo.zuruiline/controllers/widget.js
@@ -43,6 +43,8 @@ if (args.gradientEnabled) {
 
 _.each(args, function(value, key) {
   switch (key) {
+    case '__parentSymbol':   // Ignore this
+  		break;
     case 'id':
     case 'alphaBlack':
     case 'alphaWhite':
@@ -60,7 +62,7 @@ _.each(args, function(value, key) {
       break;
     default:
       // それ以外のパラメータならエラーを吐く
-      Ti.API.info('[ZuruiLine] parameter "' + key + '" is ignored.');
+      Ti.API.debug('[ZuruiLine] parameter "' + key + '" is ignored.');
       break;
   }
 });


### PR DESCRIPTION
The __parentSymbol seems to always be present and so just results in annoying console output. Also really this is a debug type message, hence level changed in default too.
